### PR TITLE
Feature/polishing kafka behavior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,6 @@ testpaths = [
     "snapstream",
     "tests",
 ]
+markers = [
+    "serial"
+]

--- a/snapstream/codecs.py
+++ b/snapstream/codecs.py
@@ -60,7 +60,7 @@ class ICodec(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def decode(self, s: bytes) -> dict:
+    def decode(self, s: bytes) -> object:
         """Deserialize object."""
         raise NotImplementedError
 

--- a/snapstream/core.py
+++ b/snapstream/core.py
@@ -239,7 +239,8 @@ class Topic(ITopic):
         offset: Optional[int] = None,
         codec: Optional[ICodec] = None,
         flush_timeout: float = -1.0,
-        poll_timeout: float = 1.0
+        poll_timeout: float = 1.0,
+        dry: bool = False
     ) -> None:
         """Pass topic related configuration."""
         c = Conf()
@@ -250,6 +251,7 @@ class Topic(ITopic):
         self.poll_timeout = poll_timeout
         self.producer = None
         self.codec = codec
+        self.dry = dry
 
     def create_topic(self, *args, **kwargs) -> None:
         """Create topic."""
@@ -273,12 +275,12 @@ class Topic(ITopic):
             for msg in consumer:
                 yield msg
 
-    def __call__(self, val, key=None, *args, dry=False, **kwargs) -> None:
+    def __call__(self, val, key=None, *args, **kwargs) -> None:
         """Produce to topic."""
         if not (key or val):
             return
         self.producer = (
             self.producer or
-            get_producer(self.name, self.conf, dry, self.codec, self.flush_timeout).__enter__()
+            get_producer(self.name, self.conf, self.dry, self.codec, self.flush_timeout).__enter__()
         )
         self.producer(key, val, *args, **kwargs)

--- a/snapstream/core.py
+++ b/snapstream/core.py
@@ -268,6 +268,8 @@ class Topic(ITopic):
 
     def __call__(self, val, key=None, *args, dry=False, **kwargs) -> None:
         """Produce to topic."""
+        if not (key or val):
+            return
         self.producer = (
             self.producer or
             get_producer(self.name, self.conf, dry, self.codec, self.flush_timeout).__enter__()

--- a/snapstream/core.py
+++ b/snapstream/core.py
@@ -140,13 +140,31 @@ class ITopic(metaclass=ABCMeta):
         raise NotImplementedError
 
 
+def _consumer_handler(c, conf, poll_timeout, codec):
+    while True:
+        msg = c.poll(poll_timeout)
+        if msg is None:
+            continue
+        if err := msg.error():
+            raise KafkaException(err)
+        if codec:
+            decoded_val = codec.decode(msg.value())
+            msg.set_value(decoded_val)
+
+        yield msg
+
+        if conf.get('enable.auto.commit') is False:
+            c.commit()
+
+
 @contextmanager
 def get_consumer(
     topic: str,
     conf: dict,
     offset=None,
     codec: Optional[ICodec] = None,
-    poll_timeout: float = 1.0
+    poll_timeout: float = 1.0,
+    poller=_consumer_handler
 ) -> Iterator[Iterable[Any]]:
     """Yield an iterable to consume from kafka."""
     c = Consumer(conf, logger=logger)
@@ -160,25 +178,16 @@ def get_consumer(
 
         logger.debug(f'Subscribing to topic: {topic}.')
         c.subscribe([topic], on_assign=on_assign)
-
         logger.debug(f'Consuming from topic: {topic}.')
-        while True:
-            msg = c.poll(poll_timeout)
-            if msg is None:
-                continue
-            if err := msg.error():
-                raise KafkaException(err)
-            if codec:
-                decoded_val = codec.decode(msg.value())
-                msg.set_value(decoded_val)
-            yield msg
+        yield from poller(c, conf, poll_timeout, codec)
+
     try:
         yield consume()
     finally:
         c.close()
 
 
-def _producer_callback(err, msg):
+def _producer_handler(err, msg):
     if err is not None:
         logger.error(f'Failed to deliver message: {err}.')
         # Raise exception by default
@@ -194,7 +203,7 @@ def get_producer(
     dry=False,
     codec: Optional[ICodec] = None,
     flush_timeout: float = -1.0,
-    callback=_producer_callback
+    callback=_producer_handler
 ) -> Iterator[Callable[[Any, Any], None]]:
     """Yield kafka produce method."""
     p = Producer(conf, logger=logger)

--- a/snapstream/core.py
+++ b/snapstream/core.py
@@ -232,8 +232,7 @@ class Topic(ITopic):
         offset: Optional[int] = None,
         codec: Optional[ICodec] = None,
         flush_timeout: float = -1.0,
-        poll_timeout: float = 1.0,
-        **kwargs,
+        poll_timeout: float = 1.0
     ) -> None:
         """Pass topic related configuration."""
         c = Conf()
@@ -245,10 +244,10 @@ class Topic(ITopic):
         self.producer = None
         self.codec = codec
 
-    def create_topic(self, name: str, *args, **kwargs) -> None:
+    def create_topic(self, *args, **kwargs) -> None:
         """Create topic."""
         admin = AdminClient(self.conf)
-        for t, f in admin.create_topics([NewTopic(name, *args, **kwargs)]).items():
+        for t, f in admin.create_topics([NewTopic(self.name, *args, **kwargs)]).items():
             try:
                 f.result()
                 logger.debug(f"Topic {t} created.")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -47,12 +47,11 @@ def test_get_consumer():
         assert isinstance(c, Iterable)
 
 
-def test_get_producer():
+def test_get_producer(mocker):
     """Should return a callable."""
     with get_producer('test', {}, flush_timeout=0) as p:
         assert isinstance(p, Callable)
-        unsent = p('test', 'test')
-        assert unsent == 1
+        p('test', 'test')
 
 
 def test_Topic():


### PR DESCRIPTION
- factoring out functions included in other functions
- ... enabling users to pass custom producer/consumer handlers
- moving dry argument to Topic level
- triggering manual commits when `enable.auto.commit` is false
- fixing some types
- no longer flushing after each message, `flush.messages` or `flush.ms` can be used instead