### PR TITLE
Feature/removing default ttl

### DIFF
--- a/snapstream/__main__.py
+++ b/snapstream/__main__.py
@@ -12,6 +12,7 @@ from re import search
 from sys import argv, exit
 from typing import Optional
 
+from rocksdict import AccessType
 from toolz import curry
 
 from snapstream import READ_FROM_END, Cache, Topic
@@ -173,7 +174,10 @@ def inspect_topic(conf: dict, args: Namespace):
 
 def inspect_cache(conf: dict, args: Namespace):
     """Read records from cache."""
-    cache = Cache(args.path)
+    cache = Cache(
+        args.path,
+        access_type=AccessType.read_only(),
+    )
     key_filter = curry(regex_filter)(args.key_filter)
     val_filter = curry(regex_filter)(args.val_filter)
     for key, val in cache.items():
@@ -182,7 +186,6 @@ def inspect_cache(conf: dict, args: Namespace):
                 raise ValueError(f'Columns could not be extracted from {type(val)}: {val}')
             print()
             print('>>> key:', key)
-            print(val)
             print(val) if not args.columns else print({
                 k: v for k, v in val.items() if k in args.columns.split(',')
             })

--- a/snapstream/caching.py
+++ b/snapstream/caching.py
@@ -20,15 +20,13 @@ class Cache:
         path: str,
         options: Union[Options, None] = None,
         column_families: Union[Dict[str, Options], None] = None,
-        access_type=AccessType.with_ttl(4 * 24 * 60 * MINUTES),
+        access_type=AccessType.read_write(),
         target_table_size=25 * MB
     ) -> None:
         """Create instance that holds rocksdb reference.
 
         This configuration setup optimizes for low disk usage (25mb per table/cf).
-        TTL is set to 4 days, older records may be removed during compaction.
-        When 25mb (target_table_size) is reached, the oldest file gets
-        deleted (the first records go out).
+        The oldest records may be removed during compaction.
 
         https://congyuwang.github.io/RocksDict/rocksdict.html
         """


### PR DESCRIPTION
- phasing out wall-time based TTL for removing old records
- using read_only access_type in snapstream CLI to load databases that are in use