### PR TITLE
Feature/usability tweaks

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -72,16 +72,13 @@ Fields can be filtered when a dictionary is returned:
   >>> key: 123
   {'value': 'A story about jack and james.'}
 
-To get some additional RocksDB statistics on the cache, pass the ``--stats`` flag:
+To see the live files of the cache and the total size, pass the ``--stats`` flag:
 
 ::
 
   snapstream cache db --stats
 
 ::
-
-  >>> key: 123
-  {'timestamp': 123, 'value': 'A story about jack and james.'}
 
   Statistics:
   [

--- a/snapstream/__main__.py
+++ b/snapstream/__main__.py
@@ -191,6 +191,12 @@ def inspect_cache(entry: dict, args: Namespace):
         args.path,
         access_type=AccessType.read_only(),
     )
+    if args.stats:
+        print()
+        print('Statistics:')
+        print(dumps(cache.live_files(), indent=4))
+        print('Folder size:', folder_size(args.path + '/**/*', 'mb'), 'mb')
+        return
     key_filter = curry(regex_filter)(args.key_filter)
     val_filter = curry(regex_filter)(args.val_filter)
     for key, val in cache.items():
@@ -202,12 +208,6 @@ def inspect_cache(entry: dict, args: Namespace):
             print(val) if not args.columns else print({
                 k: v for k, v in val.items() if k in args.columns.split(',')
             })
-
-    if args.stats:
-        print()
-        print('Statistics:')
-        print(dumps(cache.live_files(), indent=4))
-        print('Folder size:', folder_size(args.path + '/**/*', 'mb'), 'mb')
 
 
 def main():


### PR DESCRIPTION
- Using `snapstream cache --stats` in the snapstream command will now only show db stats.
- Added example docs showing an implementation of API endpoints.